### PR TITLE
ci: fix latent hadolint failure in Deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,20 +40,9 @@ jobs:
           echo "Workflow dispatch reason: $INPUTS_REASON"
           echo "Use test image: $INPUTS_USE_TEST_IMAGE"
 
-  hadolint:
-    name: Run hadolint against docker files
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Pull hadolint/hadolint:latest Image
-        run: docker pull hadolint/hadolint:latest
-      - name: Run hadolint against Dockerfiles
-        run: docker run --rm -i -v "$PWD":/workdir --workdir /workdir --entrypoint hadolint hadolint/hadolint --ignore DL3003 --ignore DL3006 --ignore DL3010 --ignore DL4001 --ignore DL3007 --ignore DL3008 --ignore SC2068 --ignore DL3007 --ignore SC1091 --ignore DL3013 --ignore DL3010 $(find . -type f -iname "Dockerfile*")
-
   build_and_push:
     name: Image Build & Push
     uses: sdr-enthusiasts/common-github-workflows/.github/workflows/sdre.yml@bcf0b94a192e7ca9630f788ecc16acd999541404 # main
-    needs: [hadolint]
     with:
       push_enabled: true
       push_destinations: ghcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,4 +67,4 @@ RUN set -x && \
 EXPOSE 30053/tcp 30054/tcp
 
 # Add healthcheck
-HEALTHCHECK --start-period=3600s --interval=600s CMD /scripts/healthcheck.sh
+HEALTHCHECK --start-period=3600s --interval=600s CMD ["/scripts/healthcheck.sh"]


### PR DESCRIPTION
## Problem

Latent rather than currently visible. The last `Deploy` runs were on 2026-07-14 and both succeeded:

```text
2026-07-14T17:05  Deploy  success
2026-07-14T15:42  Deploy  success
2026-06-26T22:01  Deploy  success
```

hadolint **v2.15.0** was published on 2026-07-30T13:39:01Z, after that. Because the `hadolint` job pulled unpinned `hadolint/hadolint:latest`, the next `Deploy` — the next time `docker-baseimage` fans out — would have gone red with nothing in this repo having changed. Replaying the job's exact command against current `:latest` (2.15.1) on the unfixed Dockerfile:

```console
$ docker run --rm -i -v "$PWD":/workdir --workdir /workdir --entrypoint hadolint hadolint/hadolint \
    --ignore DL3003 --ignore DL3006 --ignore DL3010 --ignore DL4001 --ignore DL3007 \
    --ignore DL3008 --ignore SC2068 --ignore DL3007 --ignore SC1091 --ignore DL3013 \
    --ignore DL3010 $(find . -type f -iname "Dockerfile*")
./Dockerfile:70 DL3025 warning: Use arguments JSON notation for CMD and ENTRYPOINT arguments
rc=1
```

`build_and_push` gated on that job via `needs: [hadolint]`, so this would have **blocked the image build outright**, not merely painted the run red.

## Root cause

hadolint [#1209](https://github.com/hadolint/hadolint/pull/1209) extended `DL3025` to fire on `HEALTHCHECK ... CMD` as well as `CMD`/`ENTRYPOINT`, shipping in v2.15.0. `DL3025` itself is not new; only the `HEALTHCHECK` coverage is.

```console
$ hadolint Dockerfile     # 2.14.0, the flake.lock pin
rc=0

$ docker run --rm -i --entrypoint hadolint hadolint/hadolint:latest --no-color - < Dockerfile
-:70 DL3025 warning: Use arguments JSON notation for CMD and ENTRYPOINT arguments
rc=1
```

## Changes

**`fix: use JSON exec form for HEALTHCHECK CMD`** — the actual violation:

```diff
-HEALTHCHECK --start-period=3600s --interval=600s CMD /scripts/healthcheck.sh
+HEALTHCHECK --start-period=3600s --interval=600s CMD ["/scripts/healthcheck.sh"]
```

**`ci: drop redundant hadolint job from deploy workflow`** — removes the job and the now-dangling `needs: [hadolint]`.

```console
$ yq '.jobs | keys' .github/workflows/deploy.yml
- workflow-dispatch
- build_and_push
```

Unlike `docker-adsbhub`, this repo already had `check_docker = true`, so no `flake.nix` change was needed — `lint.yaml` was already linting the Dockerfile via pre-commit. Verified rather than assumed:

```console
$ grep -o '"id": "hadolint"' .pre-commit-config.yaml
"id": "hadolint"
$ grep -o '/nix/store/[^"]*hadolint-[0-9.]*/bin/hadolint' .pre-commit-config.yaml
/nix/store/gg0zllfabq395d8i6vyn3ljbavfh4d1p-hadolint-2.14.0/bin/hadolint
$ grep -o '"files": "[^"]*Dockerfile[^"]*"' .pre-commit-config.yaml
"files": "(^|/)Dockerfile.*+$|\\.Dockerfile$"
```

## Verification

The exec form drops the intervening `/bin/sh -c`, so the kernel must resolve the script's `#!/command/with-contenv bash` shebang itself — a symlink into the s6-overlay tree, not a normal interpreter path. Preconditions hold in the published image:

```console
$ docker run --rm --entrypoint /bin/sh ghcr.io/sdr-enthusiasts/docker-planefinder:latest \
    -c 'ls -l /command/with-contenv; ls -l /scripts/healthcheck.sh; head -1 /scripts/healthcheck.sh'
lrwxrwxrwx 1 root root 48 /command/with-contenv -> ../package/admin/s6-overlay/command/with-contenv
-rwxr-xr-x 1 root root 1582 /scripts/healthcheck.sh
#!/command/with-contenv bash
```

Both forms side by side under Docker's real healthcheck machinery — the **published image** (shell form) against a **local build of this branch** (exec form), with only the probe timing overridden so it fires in reasonable time:

```text
=== published / shell ===                    === rebuilt / exec ===
unhealthy                                    unhealthy
["CMD-SHELL","/scripts/healthcheck.sh"]      ["CMD","/scripts/healthcheck.sh"]
exit=1                                       exit=1
```

Byte-identical output on both sides:

```text
Expected a hostname or IPv4 address.
Expected remote IPv4 address or 'ANY'. Given '': FAIL
Service directory /run/s6/legacy-services does not exist. FAIL
No increase in bytes sent to master server. From  to . FAIL
```

`unhealthy` is expected without a configured Planefinder sharecode and upstream feed; identical failure on both sides proves form-equivalence just as well as identical success would, and confirms exit codes still propagate in exec form. `Config.Entrypoint` is `["/init"]` on both, so s6 remains PID 1 and `docker stop` still reaches it for graceful shutdown.

Image config compared against the published image — only `Test[0]` differs:

```console
built    : {"Test":["CMD","/scripts/healthcheck.sh"],"Interval":600000000000,"StartPeriod":3600000000000}
published: {"Test":["CMD-SHELL","/scripts/healthcheck.sh"],"Interval":600000000000,"StartPeriod":3600000000000}
```

`Interval` and `StartPeriod` unchanged.

Checked at **each commit individually**, not just at the tip, so `git bisect` stays usable — including the coverage invariant, which must hold at every commit:

```text
SHA       2.14.0  2.15.1  pc-hadolint  legacy-job  subject
0f879c87  rc=0    rc=0    true         1           fix: use JSON exec form for HEALTHCHECK CMD
16d95723  rc=0    rc=0    true         0           ci: drop redundant hadolint job from deploy workflow
```

Every row satisfies `pc-hadolint=true OR legacy-job=1`, so Dockerfile linting is continuous across the series.

Also checked:

- `nix develop -c pre-commit run --all-files`: green, all hooks Passed or Skipped, including `hadolint`, `check-github-workflows` and `check-yaml`
- `docker build --platform linux/amd64`: succeeds
- The legacy job's own command now returns `rc=0` against `:latest`, so the job would pass if it were kept — it is removed because it is redundant and unpinned, not to hide a failure
- No hooks bypassed; no `--no-verify`
