### PR TITLE
chore(flake/precommit): `58a5f530` -> `9755ccd1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784288435,
-        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
+        "lastModified": 1787424939,
+        "narHash": "sha256-O2tBn84NNuHrnqNVxx/XqsXwfYvS1YwBh+7CBnbCYsk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
+        "rev": "809414f0cdadf82cf11b06c2b29ba9b3168b3297",
         "type": "github"
       },
       "original": {
@@ -98,11 +98,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1787294166,
-        "narHash": "sha256-MSchJhtWP+KQMRUlVC1AuPQItpdn3wtFoeuVdLhdbvk=",
+        "lastModified": 1788068480,
+        "narHash": "sha256-tm9HODiIKc7bUOYbzJNgZmLJaOkF0YGJ1Z1XQnzKHs0=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "58a5f5309274af48b6611cafd506383a227d7d61",
+        "rev": "9755ccd1fddcea517187bfd1d975d48bc42fe172",
         "type": "github"
       },
       "original": {
@@ -122,11 +122,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1787281715,
-        "narHash": "sha256-5yIL5XL31hCZBPWDdUOvUy4cYAl27XZrke7JELhHlnI=",
+        "lastModified": 1787993548,
+        "narHash": "sha256-+IAEnmmx5YIhUWo0lp15jLLHchnXo5yKgWsi6C6Cf+0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "89abdfd661ea493cde2f73d7b1332cb34150aa43",
+        "rev": "996e9b0b019a4a9eb9e9a5641aefa06d801b5895",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                         | Message                                               |
| -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`9755ccd1`](https://github.com/fredsystems/pre-commit-checks/commit/9755ccd1fddcea517187bfd1d975d48bc42fe172) | `` chore(flake/nixpkgs): 9fbb54b3 -> 83199d0d ``      |
| [`769c644d`](https://github.com/fredsystems/pre-commit-checks/commit/769c644de8841a18f266222dca3959d5fc159004) | `` chore(flake/rust-overlay): 04ceec13 -> 996e9b0b `` |
| [`7c899ba7`](https://github.com/fredsystems/pre-commit-checks/commit/7c899ba722adaa37e5f4d6493a49b1f3e00ec508) | `` chore(flake/nixpkgs): ffb3c9b7 -> 9fbb54b3 ``      |
| [`7b40626d`](https://github.com/fredsystems/pre-commit-checks/commit/7b40626dc16338fc4ca7ac241893df912038b8f7) | `` chore(flake/rust-overlay): 89abdfd6 -> 04ceec13 `` |
| [`68246d51`](https://github.com/fredsystems/pre-commit-checks/commit/68246d514fb79a601679ec761f3be948248318f3) | `` chore(flake/git-hooks): 43b3c1ab -> 809414f0 ``    |